### PR TITLE
예약 관련 기능 구현

### DIFF
--- a/src/main/java/com/cherryhouse/server/_core/exception/ExceptionCode.java
+++ b/src/main/java/com/cherryhouse/server/_core/exception/ExceptionCode.java
@@ -31,6 +31,12 @@ public enum ExceptionCode {
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
     CHATROOM_EXISTS(HttpStatus.BAD_REQUEST, "이미 생성된 채팅방입니다."),
 
+    // reserve --------------------
+
+    RESERVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "작성자만 예약을 관리할 수 있습니다."),
+    RESERVE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 생성된 예약입니다."),
+    RESERVE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
+
     // server ------------------
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 오류가 발생했습니다."),

--- a/src/main/java/com/cherryhouse/server/reserve/Reserve.java
+++ b/src/main/java/com/cherryhouse/server/reserve/Reserve.java
@@ -1,6 +1,7 @@
 package com.cherryhouse.server.reserve;
 
 
+import com.cherryhouse.server.post.Post;
 import com.cherryhouse.server.user.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -19,8 +20,8 @@ public class Reserve {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User provider;
@@ -41,8 +42,8 @@ public class Reserve {
 
 
     @Builder
-    public Reserve(Long postId, User provider, User receiver, Status status, LocalDate createDate, LocalDate reservationDate){
-        this.postId = postId;
+    public Reserve(Post post, User provider, User receiver, Status status, LocalDate createDate, LocalDate reservationDate){
+        this.post = post;
         this.provider = provider;
         this.receiver = receiver;
         this.status = status;

--- a/src/main/java/com/cherryhouse/server/reserve/Reserve.java
+++ b/src/main/java/com/cherryhouse/server/reserve/Reserve.java
@@ -1,0 +1,59 @@
+package com.cherryhouse.server.reserve;
+
+
+import com.cherryhouse.server.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "reserve_tb")
+public class Reserve {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User provider;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User receiver;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column
+    private LocalDate reservationDate;
+
+    @Column
+    private LocalDate createDate;
+
+
+
+    @Builder
+    public Reserve(Long postId, User provider, User receiver, Status status, LocalDate createDate, LocalDate reservationDate){
+        this.postId = postId;
+        this.provider = provider;
+        this.receiver = receiver;
+        this.status = status;
+        this.createDate = createDate;
+        this.reservationDate = reservationDate;
+
+    }
+
+    public void update(LocalDate reservationDate, Status status) {
+        this.reservationDate = reservationDate;
+        this.status = status;
+
+    }
+}

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
@@ -23,7 +23,7 @@ public class ReserveController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-    @PutMapping("/change")
+    @PutMapping
     public ResponseEntity<?> updateReserve(@AuthenticationPrincipal UserPrincipal user,
                                      @Valid @RequestBody ReserveRequest.changeReserveDto changeReserveDto){
         reserveService.update(user,changeReserveDto);

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
@@ -18,14 +18,14 @@ public class ReserveController {
 
     @PostMapping
     public ResponseEntity<?> reserve(@AuthenticationPrincipal UserPrincipal user,
-                                     @Valid @RequestBody ReserveRequest.makeReserveDto makeReserveDto){
+                                     @Valid @RequestBody ReserveRequest.MakeReserveDto makeReserveDto){
         reserveService.reserve(user,makeReserveDto);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
     @PutMapping
     public ResponseEntity<?> updateReserve(@AuthenticationPrincipal UserPrincipal user,
-                                     @Valid @RequestBody ReserveRequest.changeReserveDto changeReserveDto){
+                                     @Valid @RequestBody ReserveRequest.ChangeReserveDto changeReserveDto){
         reserveService.update(user,changeReserveDto);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
@@ -1,0 +1,35 @@
+package com.cherryhouse.server.reserve;
+
+import com.cherryhouse.server._core.security.UserPrincipal;
+import com.cherryhouse.server._core.util.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reserve")
+@RequiredArgsConstructor
+public class ReserveController {
+
+    private final ReserveService reserveService;
+
+    @PostMapping
+    public ResponseEntity<?> reserve(@AuthenticationPrincipal UserPrincipal user,
+                                     @Valid @RequestBody ReserveRequest.makeReserveDto makeReserveDto){
+        reserveService.reserve(user,makeReserveDto);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+    @PutMapping("/change")
+    public ResponseEntity<?> updateReserve(@AuthenticationPrincipal UserPrincipal user,
+                                     @Valid @RequestBody ReserveRequest.changeReserveDto changeReserveDto){
+        reserveService.update(user,changeReserveDto);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+
+
+
+}

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveController.java
@@ -4,6 +4,7 @@ import com.cherryhouse.server._core.security.UserPrincipal;
 import com.cherryhouse.server._core.util.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +28,12 @@ public class ReserveController {
                                      @Valid @RequestBody ReserveRequest.changeReserveDto changeReserveDto){
         reserveService.update(user,changeReserveDto);
         return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getReservation(@AuthenticationPrincipal UserPrincipal user, Pageable pageable){
+        ReserveResponse.ReserveDto response = reserveService.get(user.getEmail(),pageable);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
     }
 
 

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveRepository.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveRepository.java
@@ -1,0 +1,14 @@
+package com.cherryhouse.server.reserve;
+
+import com.cherryhouse.server.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReserveRepository extends JpaRepository<Reserve, Long> {
+
+
+    Optional<Reserve> findByPostIdAndReceiver(Long id, User receiver);
+
+    Optional<Reserve> findByPostIdAndProviderAndReceiver(Long id, User provider, User receiver);
+}

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveRepository.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveRepository.java
@@ -1,7 +1,10 @@
 package com.cherryhouse.server.reserve;
 
 import com.cherryhouse.server.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,4 +14,11 @@ public interface ReserveRepository extends JpaRepository<Reserve, Long> {
     Optional<Reserve> findByPostIdAndReceiver(Long id, User receiver);
 
     Optional<Reserve> findByPostIdAndProviderAndReceiver(Long id, User provider, User receiver);
+
+    @Query("select r from Reserve r " +
+            "where r.provider.email = :email " +
+            "or r.receiver.email = :email " +
+            "order by r.id " +
+            "desc ")
+    Page<Reserve> findAllByUser(String email, Pageable pageable);
 }

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveRequest.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveRequest.java
@@ -1,0 +1,36 @@
+package com.cherryhouse.server.reserve;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public class ReserveRequest {
+
+    public record makeReserveDto(
+
+            @NotBlank
+            String receiver,
+            @NotNull
+            Long postId,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+            LocalDate reservationDate
+
+    ){}
+
+    public record changeReserveDto (
+
+            @NotBlank
+            String receiver,
+
+            @NotNull
+            Long postId,
+
+            Status status,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+            LocalDate reservationDate
+    ){}
+}

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveRequest.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 public class ReserveRequest {
 
-    public record makeReserveDto(
+    public record MakeReserveDto(
 
             @NotBlank
             String receiver,
@@ -20,7 +20,7 @@ public class ReserveRequest {
 
     ){}
 
-    public record changeReserveDto (
+    public record ChangeReserveDto(
 
             @NotBlank
             String receiver,

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveResponse.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveResponse.java
@@ -1,0 +1,69 @@
+package com.cherryhouse.server.reserve;
+
+import com.cherryhouse.server._core.util.PageData;
+import com.cherryhouse.server.post.Post;
+import com.cherryhouse.server.post.dto.PostResponse;
+import com.cherryhouse.server.post.image.ImageMapping;
+import com.cherryhouse.server.post.posttag.PostTagMapping;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class ReserveResponse {
+
+    public record ReserveDto(
+
+            PageData page,
+            List<ReservePostDto> reserveList
+
+    ) {
+        public static ReserveDto of(
+                PageData pageData,
+                List<Reserve> reserveList,
+                List<PostTagMapping.TagsDto> tagsDtoList,
+                List<ImageMapping.UrlDto> urlDtoList
+        ) {
+            return new ReserveDto(
+                    pageData,
+                    reserveList.stream()
+                            .map(reserve -> new ReserveResponse.ReserveDto.ReservePostDto(
+                                    reserve,
+                                    reserve.getPost(),
+                                    PostTagMapping.getTagsByPostId(tagsDtoList, reserve.getPost().getId()),
+                                    ImageMapping.getUrlByPostId(urlDtoList, reserve.getPost().getId())
+                            ))
+                            .toList()
+            );
+        }
+
+        public record ReservePostDto(
+
+                Status status,
+                LocalDate reserveDate,
+                Long pId,
+                String pTitle,
+                String pLocation,
+                String pAddress,
+                String pDistance,
+                List<String> pTags,
+                String pImage
+
+        ) {
+            public ReservePostDto(Reserve reserve, Post post, List<String> tags, String image) {
+                this(
+                        reserve.getStatus(),
+                        reserve.getReservationDate(),
+                        post.getId(),
+                        post.getTitle(),
+                        null,
+                        null,
+                        null,
+                        tags,
+                        image
+                );
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
@@ -42,7 +42,7 @@ public class ReserveService {
     private final ImageService imageService;
 
     @Transactional
-    public void reserve(UserPrincipal user, ReserveRequest.makeReserveDto makeReserveDto) {
+    public void reserve(UserPrincipal user, ReserveRequest.MakeReserveDto makeReserveDto) {
 
         Post post = postService.getPostById(makeReserveDto.postId());
 
@@ -74,7 +74,7 @@ public class ReserveService {
     }
 
     @Transactional
-    public void update(UserPrincipal user, ReserveRequest.changeReserveDto changeReserveDto) {
+    public void update(UserPrincipal user, ReserveRequest.ChangeReserveDto changeReserveDto) {
         User provider = userService.findByEmail(user.getEmail());
         Post post = postService.getPostById(changeReserveDto.postId());
 

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
@@ -3,20 +3,29 @@ package com.cherryhouse.server.reserve;
 import com.cherryhouse.server._core.exception.ApiException;
 import com.cherryhouse.server._core.exception.ExceptionCode;
 import com.cherryhouse.server._core.security.UserPrincipal;
+import com.cherryhouse.server._core.util.PageData;
 import com.cherryhouse.server.post.Post;
 import com.cherryhouse.server.post.PostRepository;
 import com.cherryhouse.server.post.PostService;
+import com.cherryhouse.server.post.image.ImageMapping;
+import com.cherryhouse.server.post.image.ImageService;
+import com.cherryhouse.server.post.posttag.PostTagMapping;
+import com.cherryhouse.server.post.tag.TagService;
 import com.cherryhouse.server.user.User;
 import com.cherryhouse.server.user.UserRepository;
 import com.cherryhouse.server.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -29,6 +38,8 @@ public class ReserveService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final ReserveRepository reserveRepository;
+    private final TagService tagService;
+    private final ImageService imageService;
 
     @Transactional
     public void reserve(UserPrincipal user, ReserveRequest.makeReserveDto makeReserveDto) {
@@ -46,7 +57,7 @@ public class ReserveService {
         LocalDate createDate = LocalDate.from(LocalDateTime.now());
 
         Reserve reserve = Reserve.builder()
-                .postId(post.getId())
+                .post(post)
                 .provider(provider)
                 .receiver(receiver)
                 .reservationDate(reservationDate)
@@ -75,6 +86,22 @@ public class ReserveService {
                 .orElseThrow( () -> new ApiException(ExceptionCode.RESERVE_NOT_FOUND));
 
         reserve.update(changeReserveDto.reservationDate(),changeReserveDto.status());
+
+    }
+
+    public ReserveResponse.ReserveDto get(String email, Pageable pageable) {
+        Page<Reserve> reserveList = reserveRepository.findAllByUser(email, pageable);
+        List<Post> postList = reserveList.stream()
+                .map(Reserve::getPost)
+                .collect(Collectors.toList());
+
+        PageData pageData = PageData.getPageData(reserveList);
+
+
+        List<PostTagMapping.TagsDto> tagsDtoList = tagService.getTagsDtoList(postList);
+        List<ImageMapping.UrlDto> urlDtoList = imageService.getUrlDtoList(postList);
+
+        return ReserveResponse.ReserveDto.of(pageData,reserveList.getContent(),tagsDtoList,urlDtoList);
 
     }
 }

--- a/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
+++ b/src/main/java/com/cherryhouse/server/reserve/ReserveService.java
@@ -1,0 +1,80 @@
+package com.cherryhouse.server.reserve;
+
+import com.cherryhouse.server._core.exception.ApiException;
+import com.cherryhouse.server._core.exception.ExceptionCode;
+import com.cherryhouse.server._core.security.UserPrincipal;
+import com.cherryhouse.server.post.Post;
+import com.cherryhouse.server.post.PostRepository;
+import com.cherryhouse.server.post.PostService;
+import com.cherryhouse.server.user.User;
+import com.cherryhouse.server.user.UserRepository;
+import com.cherryhouse.server.user.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReserveService {
+
+    private final PostService postService;
+    private final UserService userService;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final ReserveRepository reserveRepository;
+
+    @Transactional
+    public void reserve(UserPrincipal user, ReserveRequest.makeReserveDto makeReserveDto) {
+
+        Post post = postService.getPostById(makeReserveDto.postId());
+
+        //작성자만 예약 관리 가능
+        User provider = post.getUser();
+        if (!(Objects.equals(user.getEmail(), provider.getEmail()))){
+            throw new ApiException(ExceptionCode.RESERVE_NOT_ALLOWED);
+        }
+
+        User receiver = userService.findByEmail(makeReserveDto.receiver());
+        LocalDate reservationDate = makeReserveDto.reservationDate();
+        LocalDate createDate = LocalDate.from(LocalDateTime.now());
+
+        Reserve reserve = Reserve.builder()
+                .postId(post.getId())
+                .provider(provider)
+                .receiver(receiver)
+                .reservationDate(reservationDate)
+                .createDate(createDate)
+                .status(Status.RESERVED)
+                .build();
+
+        if(reserveRepository.findByPostIdAndReceiver(post.getId(), receiver).isPresent()) {
+            throw new ApiException(ExceptionCode.RESERVE_ALREADY_EXIST);
+        }
+
+        reserveRepository.save(reserve);
+
+    }
+
+    @Transactional
+    public void update(UserPrincipal user, ReserveRequest.changeReserveDto changeReserveDto) {
+        User provider = userService.findByEmail(user.getEmail());
+        Post post = postService.getPostById(changeReserveDto.postId());
+
+        if (!(Objects.equals(post.getUser(), provider))){
+            throw new ApiException(ExceptionCode.RESERVE_NOT_ALLOWED);
+        }
+        User receiver = userService.findByEmail(changeReserveDto.receiver());
+        Reserve reserve = reserveRepository.findByPostIdAndProviderAndReceiver(changeReserveDto.postId(), provider, receiver)
+                .orElseThrow( () -> new ApiException(ExceptionCode.RESERVE_NOT_FOUND));
+
+        reserve.update(changeReserveDto.reservationDate(),changeReserveDto.status());
+
+    }
+}

--- a/src/main/java/com/cherryhouse/server/reserve/Status.java
+++ b/src/main/java/com/cherryhouse/server/reserve/Status.java
@@ -1,0 +1,8 @@
+package com.cherryhouse.server.reserve;
+
+public enum Status {
+
+    RESERVED,
+    COMPLETED,
+    CANCELED
+}


### PR DESCRIPTION
## Description
- 예약을 관리하는 테이블을 정의하였습니다.
- RESERVED / CANCELED / COMPLETED 로 구성하였습니다.
- 처음 들어오는 요청은 항상 예약 요청이라 생각되어 RESERVED 상태로 저장하는 api와 추가 요청이 들어올 경우 변경하는 api 두 개로 구성하였습니다. 방식이 별로라고 생각되면 편하게 얘기해주세용 !
- 예약 목록 확인은 provider, receiver로 등록되어있는 게시글을 다 가져옵니다.
- 피그마 참고해서 포스트에 예약상태 + 예약날짜 추가해서 구성했습니다.

## Related Issue

Issue Number: #N/A

