### PR TITLE
BadCredentialsException 에러 해결

### DIFF
--- a/src/main/java/com/cherryhouse/server/_core/config/SecurityConfig.java
+++ b/src/main/java/com/cherryhouse/server/_core/config/SecurityConfig.java
@@ -83,39 +83,10 @@ public class SecurityConfig {
         );
 
         http.addFilterBefore(new JWTAuthenticationFilter(tokenProvider,redisTemplate), UsernamePasswordAuthenticationFilter.class);
-
+//        http.exceptionHandling(handler -> handler.authenticationEntryPoint(entryPoint));
         return http.build();
 
-        //-------------------for version 6.0.2
-//        httpSecurity.csrf().disable()
-//
-//                .exceptionHandling()
-//                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-//                .accessDeniedHandler(jwtAccessDeniedHandler)
-//
-//                // enable h2-console
-//                .and()
-//                .headers()
-//                .frameOptions()
-//                .sameOrigin()
-//
-//                // 세션을 사용하지 않기 때문에 STATELESS로 설정
-//                .and()
-//                .sessionManagement()
-//                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-//
-//                .and()
-//                .authorizeHttpRequests() // HttpServletRequest를 사용하는 요청들에 대한 접근제한을 설정하겠다.
-//                .requestMatchers("/auth/**").permitAll() // 로그인 api
-//                .requestMatchers("/posts/**").permitAll() // 회원가입 api
-//                .requestMatchers(PathRequest.toH2Console()).permitAll()// h2-console, favicon.ico 요청 인증 무시
-//                .requestMatchers("/favicon.ico").permitAll()
-//                .anyRequest().authenticated() // 그 외 인증 없이 접근X
-//
-//                .and()
-//                .addFilterBefore(new JWTAuthenticationFilter(tokenProvider),UsernamePasswordAuthenticationFilter.class); // JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig class 적용
-//
-//        return httpSecurity.build();
+
     }
 
     //@Bean - 해당 메서드의 리턴되는 오브젝트트를 IoC로 등록해준다

--- a/src/main/java/com/cherryhouse/server/_core/exception/ExceptionCode.java
+++ b/src/main/java/com/cherryhouse/server/_core/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     USER_EXISTS(HttpStatus.BAD_REQUEST, "이미 회원가입된 이메일입니다."),
     BAD_USER_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 회원 요청입니다."),
+    INVALID_AUTHORITY(HttpStatus.UNAUTHORIZED, "비밀번호가 잘못되었습니다."),
 
     // auth --------------------
 

--- a/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationEntryPoint.java
+++ b/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationEntryPoint.java
@@ -2,15 +2,35 @@ package com.cherryhouse.server._core.security;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 
 @Slf4j
 @Component
 public class JWTAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+//
+//    private final HandlerExceptionResolver resolver;
+//
+//    public JWTAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+//        this.resolver = resolver;
+//    }
+//
+//    @Override
+//    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+//        log.warn("자격 증명이 필요합니다 - {}", authException.getMessage());
+//
+//        //log.info("여기2.. :{}",request.getAttribute("exception"));
+//        log.info("여기2.. :{}",request.getHeader("exception"));
+//        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+//        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
+//        //response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+//    }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {

--- a/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationEntryPoint.java
+++ b/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationEntryPoint.java
@@ -14,24 +14,6 @@ import java.io.IOException;
 @Component
 public class JWTAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-//
-//    private final HandlerExceptionResolver resolver;
-//
-//    public JWTAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
-//        this.resolver = resolver;
-//    }
-//
-//    @Override
-//    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-//        log.warn("자격 증명이 필요합니다 - {}", authException.getMessage());
-//
-//        //log.info("여기2.. :{}",request.getAttribute("exception"));
-//        log.info("여기2.. :{}",request.getHeader("exception"));
-//        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
-//        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
-//        //response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-//    }
-
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         log.warn("자격 증명이 필요합니다 - {}", authException.getMessage());

--- a/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,32 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
         }
         chain.doFilter(request, response);
     }
+
+//@Override
+//public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+//    log.info("111");
+//    try{
+//        log.info("222");
+//        String token = resolveToken(request);
+//            String isLogout = redisTemplate.opsForValue().get(token);
+//            if (ObjectUtils.isEmpty(isLogout)){
+//                Authentication authentication = tokenProvider.getAuthentication(token);
+//                SecurityContextHolder.getContext().setAuthentication(authentication);
+//                log.debug("Authentication 정보 : {}", authentication);
+//            }
+//    } catch (BadCredentialsException e) {
+//        // 비밀번호가 잘못 입력되었을 때 처리할 로직
+//        log.info("비밀번호가 잘못 입력되었습니다.");
+//        request.setAttribute("exception", e);
+//    }catch (Exception e){
+//        log.info("444");
+//        log.info("여기1.. :{}",e.getMessage());
+//        request.setAttribute("exception",e);
+//    }
+//    log.info("555");
+//    //log.info("666 : {}", request.getAttribute("exception"));
+//    chain.doFilter(request, response);
+//}
 
     //request header에서 토큰 정보를 추출함
     private String resolveToken(HttpServletRequest request){

--- a/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/cherryhouse/server/_core/security/JWTAuthenticationFilter.java
@@ -41,32 +41,6 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
-//@Override
-//public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-//    log.info("111");
-//    try{
-//        log.info("222");
-//        String token = resolveToken(request);
-//            String isLogout = redisTemplate.opsForValue().get(token);
-//            if (ObjectUtils.isEmpty(isLogout)){
-//                Authentication authentication = tokenProvider.getAuthentication(token);
-//                SecurityContextHolder.getContext().setAuthentication(authentication);
-//                log.debug("Authentication 정보 : {}", authentication);
-//            }
-//    } catch (BadCredentialsException e) {
-//        // 비밀번호가 잘못 입력되었을 때 처리할 로직
-//        log.info("비밀번호가 잘못 입력되었습니다.");
-//        request.setAttribute("exception", e);
-//    }catch (Exception e){
-//        log.info("444");
-//        log.info("여기1.. :{}",e.getMessage());
-//        request.setAttribute("exception",e);
-//    }
-//    log.info("555");
-//    //log.info("666 : {}", request.getAttribute("exception"));
-//    chain.doFilter(request, response);
-//}
-
     //request header에서 토큰 정보를 추출함
     private String resolveToken(HttpServletRequest request){
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);


### PR DESCRIPTION
## Description
- 비밀번호 잘 못 입력시 500 BadCredentialsException 에러가 떠서 Exception 부분에서 잘 못 구현한 줄 알았는데, 정상적으로 작동하는거였습니다. 보안을 위해 아이디나 비밀번호를 틀리게 입력하면, 무엇이 잘못되었는지 알려주지 않고 BadCredentialsException을 던진다고 합니다. 기존 코드에서는 아이디를 잘 못 입력하였을 때 예외처리가 되어있어서 작성해뒀던 에러 메시지가 나타났었고, 비밀번호는 따로 설정해주지 않아 BadCredentialsException가 나타났습니다. try-catch문으로 예외 처리 잡아서 401에러 나타나게 변경 하였습니다.

*참고*
https://velog.io/@refoli_20/Spring-Security-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%9D%B8%EC%A6%9D-%EC%A4%91-%EC%A0%81%EC%A0%88%ED%95%98%EC%A7%80-%EC%95%8A%EC%9D%80-BadCredentialsException-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0


*원래 참고하려했던 글들*
https://thalals.tistory.com/451
https://colabear754.tistory.com/172


## Related Issue
Issue Number: #N/A

